### PR TITLE
Generate swift test mocks from comments

### DIFF
--- a/Examples/AdvancedExamples.swift
+++ b/Examples/AdvancedExamples.swift
@@ -1,0 +1,155 @@
+import Foundation
+
+// Example demonstrating advanced Swift features support
+
+// @Stub
+protocol GenericRepository {
+    associatedtype Element
+    
+    func save(_ element: Element) throws
+    func findById(_ id: String) async -> Element?
+    func findAll() async -> [Element]
+    func delete(where predicate: @escaping (Element) -> Bool) async throws -> Int
+}
+
+// @Spy
+class CacheManager<T: Codable> {
+    private var cache: [String: T] = [:]
+    
+    func store(_ value: T, forKey key: String) throws {
+        // Implementation would store value
+    }
+    
+    func retrieve(forKey key: String) -> T? {
+        // Implementation would retrieve value
+        return cache[key]
+    }
+    
+    func remove(forKey key: String) -> Bool {
+        // Implementation would remove value
+        return cache.removeValue(forKey: key) != nil
+    }
+    
+    static func clearAll() {
+        // Implementation would clear all caches
+    }
+}
+
+// @Dummy
+class ComplexService {
+    // Property with custom getter/setter
+    var isEnabled: Bool {
+        get { return true }
+        set { /* Implementation */ }
+    }
+    
+    // Static method
+    static func configure(with settings: Settings) {
+        // Implementation would configure service
+    }
+    
+    // Method with inout parameters
+    func processData(_ data: inout [String], transform: (String) -> String) {
+        // Implementation would process data
+        data = data.map(transform)
+    }
+    
+    // Method with multiple closure parameters
+    func performOperation(
+        onStart: @escaping () -> Void,
+        onProgress: @escaping (Double) -> Void,
+        onComplete: @escaping (Result<String, Error>) -> Void
+    ) {
+        // Implementation would perform operation
+        onStart()
+        onProgress(0.5)
+        onComplete(.success("Done"))
+    }
+    
+    // Throwing method with rethrows
+    func executeWithRetry<T>(
+        _ operation: () throws -> T
+    ) rethrows -> T {
+        // Implementation would retry operation
+        return try operation()
+    }
+}
+
+// @Stub
+func complexFunction(
+    _ first: String,
+    second: Int = 10,
+    third: Bool,
+    closure: @escaping (String, Int) -> Bool
+) -> Result<String, ComplexError> {
+    // Implementation would process complex logic
+    return .success("result")
+}
+
+// @Spy
+func genericFunction<T: Equatable>(
+    items: [T],
+    predicate: @escaping (T) -> Bool
+) -> [T] {
+    // Implementation would filter items
+    return items.filter(predicate)
+}
+
+// @Dummy
+protocol EventHandler {
+    func handle<T: Event>(_ event: T) async throws
+    func canHandle<T: Event>(_ eventType: T.Type) -> Bool
+}
+
+// Supporting types and protocols
+protocol Event {
+    var timestamp: Date { get }
+    var eventId: String { get }
+}
+
+struct Settings {
+    let apiKey: String
+    let baseURL: URL
+    let timeout: TimeInterval
+}
+
+enum ComplexError: Error {
+    case invalidInput(String)
+    case processingFailed
+    case timeout
+    case custom(Error)
+}
+
+// @Stub
+extension String {
+    func customMethod() -> Bool {
+        return false
+    }
+}
+
+// @Spy
+class ObservableProperty<T> {
+    private var _value: T
+    private var observers: [(T) -> Void] = []
+    
+    var value: T {
+        get { return _value }
+        set {
+            _value = newValue
+            notifyObservers()
+        }
+    }
+    
+    init(_ initialValue: T) {
+        self._value = initialValue
+    }
+    
+    func observe(_ observer: @escaping (T) -> Void) {
+        observers.append(observer)
+        observer(_value) // Send current value immediately
+    }
+    
+    private func notifyObservers() {
+        observers.forEach { $0(_value) }
+    }
+}

--- a/Examples/AsyncExamples.swift
+++ b/Examples/AsyncExamples.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+// Example demonstrating async/await support
+
+// @Stub
+protocol AsyncNetworkService {
+    func fetchUserData(userId: String) async throws -> UserData
+    func uploadFile(_ data: Data, to url: URL) async -> UploadResult
+    func syncData() async throws
+}
+
+// @Spy  
+class AsyncUserManager {
+    func createUser(name: String, email: String) async throws -> User {
+        // Implementation would validate and create user
+        throw UserCreationError.invalidEmail
+    }
+    
+    func updateUserProfile(_ user: User, newName: String) async -> Bool {
+        // Implementation would update user profile
+        return true
+    }
+    
+    func deleteUser(withId id: String) async throws {
+        // Implementation would delete user
+    }
+}
+
+// @Dummy
+enum UserCreationError: Error {
+    case invalidEmail
+    case duplicateUsername
+    case networkError
+    case serverError(String)
+}
+
+struct UserData {
+    let id: String
+    let name: String
+    let email: String
+    let createdAt: Date
+}
+
+struct User {
+    let id: String
+    let name: String
+    let email: String
+}
+
+enum UploadResult {
+    case success(URL)
+    case failure(Error)
+    case inProgress(Double)
+}

--- a/Examples/CallbackExamples.swift
+++ b/Examples/CallbackExamples.swift
@@ -1,0 +1,120 @@
+import Foundation
+
+// Example demonstrating callback-based async patterns
+
+// @Stub
+protocol CallbackNetworkService {
+    func request(
+        url: URL,
+        method: HTTPMethod,
+        completion: @escaping (Result<Data, NetworkError>) -> Void
+    )
+    
+    func downloadFile(
+        from url: URL,
+        progressHandler: @escaping (Double) -> Void,
+        completion: @escaping (Result<URL, Error>) -> Void
+    )
+    
+    func batchUpload(
+        files: [Data],
+        onProgress: @escaping (Int, Int) -> Void,
+        onComplete: @escaping ([UploadResult]) -> Void
+    )
+}
+
+// @Spy
+class CallbackAuthService {
+    func authenticate(
+        credentials: Credentials,
+        success: @escaping (AuthToken) -> Void,
+        failure: @escaping (AuthError) -> Void
+    ) {
+        // Implementation would authenticate user
+        success(AuthToken(token: "dummy-token"))
+    }
+    
+    func refreshToken(
+        _ token: AuthToken,
+        completion: @escaping (Result<AuthToken, AuthError>) -> Void
+    ) {
+        // Implementation would refresh token
+        completion(.success(token))
+    }
+}
+
+// @Dummy
+enum HTTPMethod: String {
+    case GET = "GET"
+    case POST = "POST"
+    case PUT = "PUT"
+    case DELETE = "DELETE"
+    case PATCH = "PATCH"
+}
+
+// @Spy
+func processPayment(
+    amount: Double,
+    card: CreditCard,
+    onSuccess: @escaping (PaymentResult) -> Void,
+    onFailure: @escaping (PaymentError) -> Void
+) {
+    // Implementation would process payment
+    onSuccess(PaymentResult(transactionId: "12345", amount: amount))
+}
+
+// @Stub
+func validateCreditCard(
+    _ card: CreditCard,
+    completion: @escaping (Bool, ValidationError?) -> Void
+) {
+    // Implementation would validate credit card
+    completion(true, nil)
+}
+
+// Supporting types
+struct Credentials {
+    let username: String
+    let password: String
+}
+
+struct AuthToken {
+    let token: String
+    let expiresAt: Date = Date().addingTimeInterval(3600)
+}
+
+enum AuthError: Error {
+    case invalidCredentials
+    case tokenExpired
+    case networkError
+}
+
+enum NetworkError: Error {
+    case noConnection
+    case timeout
+    case serverError(Int)
+}
+
+struct CreditCard {
+    let number: String
+    let expiryDate: String
+    let cvv: String
+}
+
+struct PaymentResult {
+    let transactionId: String
+    let amount: Double
+    let timestamp: Date = Date()
+}
+
+enum PaymentError: Error {
+    case insufficientFunds
+    case invalidCard
+    case processingError
+}
+
+enum ValidationError: Error {
+    case invalidNumber
+    case expiredCard
+    case invalidCVV
+}

--- a/Examples/ExampleCode.swift
+++ b/Examples/ExampleCode.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+// @Stub
+protocol NetworkServiceProtocol {
+    func fetchData() async throws -> Data
+    func uploadData(_ data: Data, completion: @escaping (Result<Bool, Error>) -> Void)
+    func processRequest(with parameters: [String: Any]) -> String
+}
+
+// @Spy
+class UserService {
+    func loginUser(username: String, password: String) async throws -> Bool {
+        // Implementation would go here
+        return true
+    }
+    
+    func logoutUser() {
+        // Implementation would go here
+    }
+    
+    func getCurrentUser() -> User? {
+        // Implementation would go here
+        return nil
+    }
+}
+
+// @Dummy
+enum UserRole {
+    case admin
+    case user
+    case guest
+    case moderator
+}
+
+// @Stub
+func validateEmail(_ email: String) -> Bool {
+    // Implementation would go here
+    return email.contains("@")
+}
+
+// @Spy
+func sendNotification(title: String, body: String, completion: @escaping (Bool) -> Void) {
+    // Implementation would go here
+    completion(true)
+}
+
+struct User {
+    let id: String
+    let username: String
+    let email: String
+    let role: UserRole
+}
+
+// @Dummy
+class DatabaseManager {
+    func saveUser(_ user: User) throws {
+        // Implementation would go here
+    }
+    
+    func fetchUser(by id: String) async -> User? {
+        // Implementation would go here
+        return nil
+    }
+    
+    func deleteUser(with id: String) async throws -> Bool {
+        // Implementation would go here
+        return true
+    }
+}

--- a/Examples/TestingExample.swift
+++ b/Examples/TestingExample.swift
@@ -1,0 +1,199 @@
+import XCTest
+import Foundation
+
+// This file shows how to use the generated mocks in your tests
+// Run SwiftMockGenerator on the service files first to generate the mocks
+
+// Example service that we want to test
+class UserManager {
+    private let networkService: NetworkServiceProtocol
+    private let authService: AuthenticationService
+    private let logger: LoggerProtocol?
+    
+    init(
+        networkService: NetworkServiceProtocol,
+        authService: AuthenticationService,
+        logger: LoggerProtocol? = nil
+    ) {
+        self.networkService = networkService
+        self.authService = authService
+        self.logger = logger
+    }
+    
+    func authenticateAndFetchUser(username: String, password: String) async throws -> User? {
+        // First authenticate
+        let isAuthenticated = try await authService.login(username: username, password: password)
+        guard isAuthenticated else { return nil }
+        
+        // Then fetch user data
+        let userData = try await networkService.fetchData()
+        return parseUser(from: userData)
+    }
+    
+    func updateUserSettings(_ user: User, settings: UserSettings) async -> Bool {
+        logger?.log("Updating settings for user: \(user.id)")
+        
+        let success = await networkService.updateUser(user)
+        if success {
+            logger?.log("Successfully updated user settings")
+        } else {
+            logger?.log("Failed to update user settings")
+        }
+        
+        return success
+    }
+    
+    private func parseUser(from data: Data) -> User? {
+        // Parsing implementation
+        return User(id: "1", name: "Test User", email: "test@example.com")
+    }
+}
+
+// MARK: - Test Cases
+
+class UserManagerTests: XCTestCase {
+    
+    // Test using Stub - when you need working implementations
+    func testAuthenticateAndFetchUser_WithStub() async throws {
+        // Arrange
+        let networkStub = NetworkServiceProtocolStub()
+        let authStub = AuthenticationServiceStub()
+        let userManager = UserManager(
+            networkService: networkStub,
+            authService: authStub
+        )
+        
+        // Act
+        let user = try await userManager.authenticateAndFetchUser(
+            username: "testuser",
+            password: "password"
+        )
+        
+        // Assert
+        XCTAssertNotNil(user)
+        XCTAssertEqual(user?.name, "Test User")
+    }
+    
+    // Test using Spy - when you need to verify interactions
+    func testUpdateUserSettings_WithSpy() async throws {
+        // Arrange
+        let networkSpy = NetworkServiceProtocolSpy()
+        let authSpy = AuthenticationServiceSpy()
+        let loggerSpy = LoggerProtocolSpy()
+        
+        let userManager = UserManager(
+            networkService: networkSpy,
+            authService: authSpy,
+            logger: loggerSpy
+        )
+        
+        let user = User(id: "123", name: "Test", email: "test@example.com")
+        let settings = UserSettings(theme: .dark, notifications: true)
+        
+        // Act
+        let result = await userManager.updateUserSettings(user, settings: settings)
+        
+        // Assert - Verify method calls
+        XCTAssertTrue(networkSpy.verifyUpdateUserCalled())
+        XCTAssertTrue(networkSpy.verifyUpdateUserCalledWith(user))
+        XCTAssertEqual(networkSpy.updateUserCallCount, 1)
+        
+        // Verify logging
+        XCTAssertTrue(loggerSpy.verifyLogCalled())
+        XCTAssertTrue(loggerSpy.logCallCount >= 1)
+    }
+    
+    // Test using Dummy - when dependencies won't be called
+    func testUserManagerInitialization() {
+        // Arrange - Using dummies since we're not calling their methods
+        let networkDummy = NetworkServiceProtocolDummy()
+        let authDummy = AuthenticationServiceDummy()
+        
+        // Act
+        let userManager = UserManager(
+            networkService: networkDummy,
+            authService: authDummy
+        )
+        
+        // Assert - Just verify initialization
+        XCTAssertNotNil(userManager)
+    }
+    
+    // Test combining different mock types
+    func testComplexScenario() async throws {
+        // Arrange - Mix of mock types based on needs
+        let networkSpy = NetworkServiceProtocolSpy()  // Need to verify network calls
+        let authStub = AuthenticationServiceStub()     // Need working auth
+        let loggerDummy = LoggerProtocolDummy()        // Won't check logging
+        
+        let userManager = UserManager(
+            networkService: networkSpy,
+            authService: authStub,
+            logger: loggerDummy
+        )
+        
+        let user = User(id: "456", name: "Another User", email: "user@example.com")
+        let settings = UserSettings(theme: .light, notifications: false)
+        
+        // Act
+        let result = await userManager.updateUserSettings(user, settings: settings)
+        
+        // Assert - Focus on what matters for this test
+        XCTAssertTrue(result)
+        XCTAssertTrue(networkSpy.verifyUpdateUserCalledWith(user))
+        // Don't need to verify auth or logging for this test
+    }
+}
+
+// MARK: - Supporting Types
+
+struct User {
+    let id: String
+    let name: String
+    let email: String
+}
+
+struct UserSettings {
+    let theme: Theme
+    let notifications: Bool
+}
+
+enum Theme {
+    case light
+    case dark
+    case auto
+}
+
+// These would be in separate files with mock annotations
+
+protocol NetworkServiceProtocol {
+    func fetchData() async throws -> Data
+    func updateUser(_ user: User) async -> Bool
+}
+
+class AuthenticationService {
+    func login(username: String, password: String) async throws -> Bool {
+        return true
+    }
+}
+
+protocol LoggerProtocol {
+    func log(_ message: String)
+}
+
+// MARK: - Expected Generated Mocks
+/*
+ After running SwiftMockGenerator, you would have:
+ 
+ 1. NetworkServiceProtocolStub.swift
+ 2. NetworkServiceProtocolSpy.swift  
+ 3. NetworkServiceProtocolDummy.swift
+ 4. AuthenticationServiceStub.swift
+ 5. AuthenticationServiceSpy.swift
+ 6. AuthenticationServiceDummy.swift
+ 7. LoggerProtocolStub.swift
+ 8. LoggerProtocolSpy.swift
+ 9. LoggerProtocolDummy.swift
+ 
+ Each with appropriate implementations based on the mock type.
+*/

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,36 @@
+// swift-tools-version: 5.9
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "SwiftMockGenerator",
+    platforms: [
+        .macOS(.v12)
+    ],
+    products: [
+        .executable(
+            name: "swift-mock-generator",
+            targets: ["SwiftMockGenerator"]
+        ),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-syntax.git", from: "509.0.0"),
+        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.2.0"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "SwiftMockGenerator",
+            dependencies: [
+                .product(name: "SwiftSyntax", package: "swift-syntax"),
+                .product(name: "SwiftParser", package: "swift-syntax"),
+                .product(name: "SwiftSyntaxTree", package: "swift-syntax"),
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+            ]
+        ),
+        .testTarget(
+            name: "SwiftMockGeneratorTests",
+            dependencies: ["SwiftMockGenerator"]
+        ),
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,274 @@
 # SwiftMockGenerator
+
+A Swift command-line tool that automatically generates mock objects for testing from annotated source code. Generate stubs, spies, and dummies for classes, protocols, enums, and functions by simply adding comments to your Swift code.
+
+## Features
+
+- **Multiple Mock Types**: Generate Stubs, Spies, and Dummies
+- **Comprehensive Support**: Works with classes, protocols, enums, and functions
+- **Async/Await Support**: Full support for async functions and throwing functions
+- **Callback Support**: Handles traditional callback-based async patterns
+- **Smart Generation**: Automatically handles different parameter types and return values
+- **CLI Interface**: Easy-to-use command-line interface
+
+## Installation
+
+### Requirements
+
+- Swift 5.9 or later
+- macOS 12.0 or later
+
+### Build from Source
+
+1. Clone this repository:
+```bash
+git clone <repository-url>
+cd SwiftMockGenerator
+```
+
+2. Build the executable:
+```bash
+swift build -c release
+```
+
+3. The executable will be available at:
+```bash
+.build/release/swift-mock-generator
+```
+
+4. (Optional) Add to your PATH for global access:
+```bash
+cp .build/release/swift-mock-generator /usr/local/bin/
+```
+
+## Usage
+
+### Basic Usage
+
+```bash
+swift-mock-generator path/to/your/file.swift
+```
+
+### Advanced Options
+
+```bash
+swift-mock-generator file1.swift file2.swift --output Generated --verbose
+```
+
+### Options
+
+- `--output, -o`: Specify output directory for generated mocks (default: "Generated")
+- `--verbose, -v`: Enable verbose output
+- `--help`: Show help information
+
+## Mock Types
+
+### Stubs (@Stub)
+
+Stubs provide basic implementations that return default values. Perfect for when you need a working implementation that doesn't interfere with your tests.
+
+```swift
+// @Stub
+protocol DataService {
+    func fetchUser(id: String) async throws -> User?
+    func saveUser(_ user: User) -> Bool
+}
+```
+
+Generated stub will provide default return values for all methods.
+
+### Spies (@Spy)
+
+Spies track method calls and parameters, allowing you to verify interactions in your tests. They include verification methods to check if methods were called with specific parameters.
+
+```swift
+// @Spy
+class NetworkManager {
+    func request(url: String, method: HTTPMethod) async throws -> Data {
+        // Original implementation
+    }
+}
+```
+
+Generated spy will track:
+- Call count for each method
+- Whether methods were called
+- Parameters received for each call
+- Verification methods for testing
+
+### Dummies (@Dummy)
+
+Dummies provide minimal implementations that either return basic values or fail explicitly. Use them when you need objects that won't be called in your test scenario.
+
+```swift
+// @Dummy
+enum UserRole {
+    case admin
+    case user
+    case guest
+}
+```
+
+## Supported Swift Features
+
+### Classes and Protocols
+
+```swift
+// @Stub
+class UserService {
+    func authenticate(username: String, password: String) async throws -> Bool {
+        return false
+    }
+}
+
+// @Spy
+protocol NetworkProtocol {
+    func get(_ url: URL) async throws -> Data
+    func post(_ url: URL, body: Data) async throws -> Data
+}
+```
+
+### Functions
+
+```swift
+// @Stub
+func validateEmail(_ email: String) -> Bool {
+    return email.contains("@")
+}
+
+// @Spy
+func processData(_ data: [String], completion: @escaping ([String]) -> Void) {
+    completion(data)
+}
+```
+
+### Enums
+
+```swift
+// @Dummy
+enum APIError: Error {
+    case invalidURL
+    case networkError
+    case decodingError
+}
+```
+
+### Async/Await and Throwing Functions
+
+The tool automatically handles:
+- `async` functions
+- `throws` functions
+- `async throws` functions
+- Callback-based async patterns
+
+## Example
+
+Given this input file (`UserService.swift`):
+
+```swift
+import Foundation
+
+// @Stub
+protocol UserServiceProtocol {
+    func fetchUser(id: String) async throws -> User?
+    func updateUser(_ user: User) -> Bool
+}
+
+// @Spy
+class AuthenticationService {
+    func login(username: String, password: String) async throws -> Bool {
+        // Implementation
+        return true
+    }
+}
+
+struct User {
+    let id: String
+    let name: String
+}
+```
+
+Running:
+```bash
+swift-mock-generator UserService.swift
+```
+
+Will generate:
+- `Generated/UserService_Stub_UserServiceProtocol.swift`
+- `Generated/UserService_Spy_AuthenticationService.swift`
+
+## Generated Mock Examples
+
+### Stub Example
+
+```swift
+class UserServiceProtocolStub: UserServiceProtocol {
+    init() {}
+    
+    func fetchUser(id: String) async throws -> User? {
+        return nil
+    }
+    
+    func updateUser(_ user: User) -> Bool {
+        return false
+    }
+}
+```
+
+### Spy Example
+
+```swift
+class AuthenticationServiceSpy: AuthenticationService {
+    private(set) var loginCallCount = 0
+    private(set) var loginCalled = false
+    private(set) var loginReceivedParameters: [(String, String)] = []
+    
+    override init() {
+        super.init()
+    }
+    
+    override func login(username: String, password: String) async throws -> Bool {
+        loginCallCount += 1
+        loginCalled = true
+        loginReceivedParameters.append((username, password))
+        return false
+    }
+    
+    // MARK: - Verification Methods
+    
+    func verifyLoginCalled() -> Bool {
+        return loginCalled
+    }
+    
+    func verifyLoginCallCount(_ expectedCount: Int) -> Bool {
+        return loginCallCount == expectedCount
+    }
+    
+    func verifyLoginCalledWith(username: String, password: String) -> Bool {
+        return loginReceivedParameters.contains { receivedParams in
+            receivedParams.0 == username && receivedParams.1 == password
+        }
+    }
+}
+```
+
+## Integration with Testing
+
+Use the generated mocks in your tests:
+
+```swift
+func testUserAuthentication() async throws {
+    let authSpy = AuthenticationServiceSpy()
+    let userService = UserService(authService: authSpy)
+    
+    let result = try await userService.authenticateUser(username: "test", password: "pass")
+    
+    XCTAssertTrue(authSpy.verifyLoginCalled())
+    XCTAssertTrue(authSpy.verifyLoginCalledWith(username: "test", password: "pass"))
+    XCTAssertEqual(authSpy.loginCallCount, 1)
+}
+```
+
+## License
+
+This project is available under the MIT License.

--- a/Sources/SwiftMockGenerator/DummyGenerator.swift
+++ b/Sources/SwiftMockGenerator/DummyGenerator.swift
@@ -1,0 +1,248 @@
+import SwiftSyntax
+import Foundation
+
+/// Generates dummy implementations with minimal, do-nothing behavior
+class DummyGenerator: BaseMockGenerator {
+    
+    override func generateMock(for declaration: any DeclSyntaxProtocol, in sourceFile: SourceFileSyntax, originalPath: String) throws -> String {
+        let imports = extractImports(from: sourceFile)
+        let declarationName = extractDeclarationName(from: declaration)
+        
+        var mockCode = generateHeader(originalPath: originalPath, declarationName: declarationName)
+        mockCode += generateImports(imports)
+        mockCode += "\n"
+        
+        if let classDecl = declaration.as(ClassDeclSyntax.self) {
+            mockCode += generateClassDummy(from: classDecl)
+        } else if let protocolDecl = declaration.as(ProtocolDeclSyntax.self) {
+            mockCode += generateProtocolDummy(from: protocolDecl)
+        } else if let enumDecl = declaration.as(EnumDeclSyntax.self) {
+            mockCode += generateEnumDummy(from: enumDecl)
+        } else if let functionDecl = declaration.as(FunctionDeclSyntax.self) {
+            mockCode += generateFunctionDummy(from: functionDecl)
+        } else {
+            throw MockGeneratorError.unsupportedDeclaration(String(describing: type(of: declaration)))
+        }
+        
+        return mockCode
+    }
+    
+    private func generateHeader(originalPath: String, declarationName: String) -> String {
+        let fileName = URL(fileURLWithPath: originalPath).lastPathComponent
+        return """
+        //
+        // \(declarationName)Dummy.swift
+        // Generated dummy mock from \(fileName)
+        // Created by SwiftMockGenerator
+        //
+        
+        """
+    }
+    
+    private func generateImports(_ imports: [String]) -> String {
+        var result = ""
+        for importStatement in imports {
+            result += "\(importStatement)\n"
+        }
+        if !imports.contains("Foundation") && !imports.contains(where: { $0.contains("Foundation") }) {
+            result += "import Foundation\n"
+        }
+        return result
+    }
+    
+    private func generateClassDummy(from classDecl: ClassDeclSyntax) -> String {
+        let className = classDecl.name.text
+        let dummyClassName = "\(className)Dummy"
+        let functions = extractFunctions(from: classDecl)
+        
+        var classCode = "class \(dummyClassName): \(className) {\n"
+        
+        // Generate minimal initializer
+        classCode += "    override init() {\n"
+        classCode += "        super.init()\n"
+        classCode += "    }\n\n"
+        
+        // Generate dummy methods (only for non-inherited methods)
+        for function in functions {
+            classCode += generateDummyMethod(from: function)
+            classCode += "\n"
+        }
+        
+        classCode += "}\n"
+        return classCode
+    }
+    
+    private func generateProtocolDummy(from protocolDecl: ProtocolDeclSyntax) -> String {
+        let protocolName = protocolDecl.name.text
+        let dummyClassName = "\(protocolName)Dummy"
+        let functions = extractFunctions(from: protocolDecl)
+        
+        var classCode = "class \(dummyClassName): \(protocolName) {\n"
+        
+        // Generate minimal initializer
+        classCode += "    init() {}\n\n"
+        
+        // Generate dummy methods
+        for function in functions {
+            classCode += generateDummyMethod(from: function)
+            classCode += "\n"
+        }
+        
+        classCode += "}\n"
+        return classCode
+    }
+    
+    private func generateEnumDummy(from enumDecl: EnumDeclSyntax) -> String {
+        let enumName = enumDecl.name.text
+        let dummyClassName = "\(enumName)Dummy"
+        
+        // For enums, we create a helper class that provides a dummy value
+        var classCode = "class \(dummyClassName) {\n"
+        classCode += "    static let value: \(enumName) = .\(extractFirstCase(from: enumDecl))\n"
+        classCode += "    \n"
+        classCode += "    private init() {} // Prevent instantiation\n"
+        classCode += "}\n"
+        
+        return classCode
+    }
+    
+    private func generateFunctionDummy(from functionDecl: FunctionDeclSyntax) -> String {
+        let signature = createFunctionSignature(from: functionDecl)!
+        let functionName = "\(signature.name)Dummy"
+        
+        var functionCode = "func \(functionName)"
+        functionCode += generateParameterList(from: signature)
+        
+        if let returnType = signature.returnType {
+            functionCode += " -> \(returnType)"
+        }
+        
+        if signature.isAsync {
+            functionCode += " async"
+        }
+        
+        if signature.isThrowing {
+            functionCode += " throws"
+        }
+        
+        functionCode += " {\n"
+        functionCode += "    // Dummy implementation - does nothing\n"
+        
+        if let returnType = signature.returnType, returnType != "Void" {
+            let defaultReturn = generateMinimalReturnValue(for: returnType)
+            functionCode += "    \(defaultReturn)\n"
+        }
+        
+        functionCode += "}\n"
+        
+        return functionCode
+    }
+    
+    private func generateDummyMethod(from signature: FunctionSignature) -> String {
+        var methodCode = "    \(signature.accessLevel) func \(signature.name)"
+        methodCode += generateParameterList(from: signature)
+        
+        if let returnType = signature.returnType {
+            methodCode += " -> \(returnType)"
+        }
+        
+        if signature.isAsync {
+            methodCode += " async"
+        }
+        
+        if signature.isThrowing {
+            methodCode += " throws"
+        }
+        
+        methodCode += " {\n"
+        methodCode += "        // Dummy implementation - does nothing\n"
+        
+        if let returnType = signature.returnType, returnType != "Void" {
+            let defaultReturn = generateMinimalReturnValue(for: returnType)
+            methodCode += "        \(defaultReturn)\n"
+        }
+        
+        methodCode += "    }"
+        
+        return methodCode
+    }
+    
+    private func generateParameterList(from signature: FunctionSignature) -> String {
+        guard !signature.parameters.isEmpty else { return "()" }
+        
+        let params = signature.parameters.map { param in
+            var paramStr = ""
+            if let firstName = param.firstName {
+                paramStr = "\(firstName) \(param.secondName): \(param.type)"
+            } else {
+                paramStr = "\(param.secondName): \(param.type)"
+            }
+            return paramStr
+        }.joined(separator: ", ")
+        
+        return "(\(params))"
+    }
+    
+    /// Generate minimal return values for dummy implementations
+    private func generateMinimalReturnValue(for type: String) -> String {
+        let cleanType = type.trimmingCharacters(in: .whitespaces)
+        
+        switch cleanType {
+        case "Void", "()":
+            return ""
+        case "String":
+            return "return \"\"" // Empty string
+        case "Int", "Int8", "Int16", "Int32", "Int64":
+            return "return 0"
+        case "UInt", "UInt8", "UInt16", "UInt32", "UInt64":
+            return "return 0"
+        case "Double", "Float", "CGFloat":
+            return "return 0.0"
+        case "Bool":
+            return "return false"
+        case let t where t.hasPrefix("[") && t.hasSuffix("]"):
+            return "return []" // Empty array
+        case let t where t.hasPrefix("Set<") && t.hasSuffix(">"):
+            return "return Set()" // Empty set
+        case let t where t.hasPrefix("Dictionary<") && t.hasSuffix(">"):
+            return "return [:]" // Empty dictionary
+        case let t where t.hasSuffix("?"):
+            return "return nil" // Optional types return nil
+        default:
+            if cleanType.contains("->") {
+                // Function type - return empty closure
+                return "return { _ in }"
+            } else if cleanType.starts(with: "@") {
+                // Escaping closures
+                return "return { _ in }"
+            } else {
+                // For custom types, return fatalError to make it obvious this is a dummy
+                return "fatalError(\"Dummy implementation - not meant to be called\")"
+            }
+        }
+    }
+    
+    private func extractDeclarationName(from declaration: any DeclSyntaxProtocol) -> String {
+        if let classDecl = declaration.as(ClassDeclSyntax.self) {
+            return classDecl.name.text
+        } else if let protocolDecl = declaration.as(ProtocolDeclSyntax.self) {
+            return protocolDecl.name.text
+        } else if let enumDecl = declaration.as(EnumDeclSyntax.self) {
+            return enumDecl.name.text
+        } else if let functionDecl = declaration.as(FunctionDeclSyntax.self) {
+            return functionDecl.name.text
+        }
+        return "Unknown"
+    }
+    
+    private func extractFirstCase(from enumDecl: EnumDeclSyntax) -> String {
+        for member in enumDecl.memberBlock.members {
+            if let caseDecl = member.decl.as(EnumCaseDeclSyntax.self) {
+                if let firstCase = caseDecl.elements.first {
+                    return firstCase.name.text
+                }
+            }
+        }
+        return "defaultCase"
+    }
+}

--- a/Sources/SwiftMockGenerator/MockAnnotationVisitor.swift
+++ b/Sources/SwiftMockGenerator/MockAnnotationVisitor.swift
@@ -1,0 +1,78 @@
+import SwiftSyntax
+import Foundation
+
+/// Visitor that walks through Swift syntax tree to find mock annotations
+class MockAnnotationVisitor: SyntaxVisitor {
+    private(set) var annotations: [MockAnnotation] = []
+    private var sourceLines: [String] = []
+    
+    override func visit(_ sourceFile: SourceFileSyntax) -> SyntaxVisitorContinueKind {
+        // Store source lines for comment analysis
+        let sourceText = sourceFile.description
+        sourceLines = sourceText.components(separatedBy: .newlines)
+        return .visitChildren
+    }
+    
+    override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
+        checkForAnnotation(before: node, declaration: node, name: node.name.text)
+        return .visitChildren
+    }
+    
+    override func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
+        checkForAnnotation(before: node, declaration: node, name: node.name.text)
+        return .visitChildren
+    }
+    
+    override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
+        checkForAnnotation(before: node, declaration: node, name: node.name.text)
+        return .visitChildren
+    }
+    
+    override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
+        checkForAnnotation(before: node, declaration: node, name: node.name.text)
+        return .visitChildren
+    }
+    
+    /// Check if there's a mock annotation comment before the given declaration
+    private func checkForAnnotation(before node: some SyntaxProtocol, declaration: any DeclSyntaxProtocol, name: String) {
+        let position = node.position
+        let lineNumber = getLineNumber(for: position)
+        
+        // Check the line before the declaration for annotation comments
+        guard lineNumber > 0 else { return }
+        
+        let commentLineIndex = lineNumber - 1
+        guard commentLineIndex < sourceLines.count else { return }
+        
+        let commentLine = sourceLines[commentLineIndex].trimmingCharacters(in: .whitespaces)
+        
+        for mockType in MockType.allCases {
+            if commentLine.contains("// \(mockType.commentPattern)") {
+                let annotation = MockAnnotation(
+                    mockType: mockType,
+                    declaration: declaration,
+                    declarationName: name,
+                    lineNumber: lineNumber
+                )
+                annotations.append(annotation)
+                break
+            }
+        }
+    }
+    
+    /// Convert AbsolutePosition to line number (1-based)
+    private func getLineNumber(for position: AbsolutePosition) -> Int {
+        let utf8Offset = position.utf8Offset
+        var currentOffset = 0
+        
+        for (index, line) in sourceLines.enumerated() {
+            let lineLength = line.utf8.count + 1 // +1 for newline
+            if currentOffset + lineLength > utf8Offset {
+                return index + 1 // 1-based line number
+            }
+            currentOffset += lineLength
+        }
+        
+        return sourceLines.count
+    }
+}

--- a/Sources/SwiftMockGenerator/MockCodeGenerator.swift
+++ b/Sources/SwiftMockGenerator/MockCodeGenerator.swift
@@ -1,0 +1,144 @@
+import SwiftSyntax
+import Foundation
+
+/// Protocol that all mock generators must implement
+protocol MockCodeGenerator {
+    func generateMock(for declaration: any DeclSyntaxProtocol, in sourceFile: SourceFileSyntax, originalPath: String) throws -> String
+}
+
+/// Base class for mock generators with common functionality
+class BaseMockGenerator: MockCodeGenerator {
+    
+    func generateMock(for declaration: any DeclSyntaxProtocol, in sourceFile: SourceFileSyntax, originalPath: String) throws -> String {
+        fatalError("Subclasses must implement generateMock")
+    }
+    
+    /// Extract imports from the original source file
+    func extractImports(from sourceFile: SourceFileSyntax) -> [String] {
+        var imports: [String] = []
+        
+        for statement in sourceFile.statements {
+            if let importDecl = statement.item.as(ImportDeclSyntax.self) {
+                let importText = importDecl.description.trimmingCharacters(in: .whitespacesAndNewlines)
+                imports.append(importText)
+            }
+        }
+        
+        return imports
+    }
+    
+    /// Extract function signatures from a declaration
+    func extractFunctions(from declaration: any DeclSyntaxProtocol) -> [FunctionSignature] {
+        var functions: [FunctionSignature] = []
+        
+        if let classDecl = declaration.as(ClassDeclSyntax.self) {
+            functions = extractFunctionsFromMembers(classDecl.memberBlock.members)
+        } else if let protocolDecl = declaration.as(ProtocolDeclSyntax.self) {
+            functions = extractFunctionsFromMembers(protocolDecl.memberBlock.members)
+        } else if let functionDecl = declaration.as(FunctionDeclSyntax.self) {
+            if let signature = createFunctionSignature(from: functionDecl) {
+                functions = [signature]
+            }
+        }
+        
+        return functions
+    }
+    
+    /// Extract functions from member block
+    private func extractFunctionsFromMembers(_ members: MemberBlockItemListSyntax) -> [FunctionSignature] {
+        var functions: [FunctionSignature] = []
+        
+        for member in members {
+            if let functionDecl = member.decl.as(FunctionDeclSyntax.self) {
+                if let signature = createFunctionSignature(from: functionDecl) {
+                    functions.append(signature)
+                }
+            }
+        }
+        
+        return functions
+    }
+    
+    /// Create function signature from FunctionDeclSyntax
+    func createFunctionSignature(from functionDecl: FunctionDeclSyntax) -> FunctionSignature? {
+        let name = functionDecl.name.text
+        
+        // Extract parameters
+        let parameters = functionDecl.signature.parameterClause.parameters.map { param in
+            FunctionSignature.Parameter(
+                firstName: param.firstName?.text,
+                secondName: param.secondName?.text ?? param.firstName.text,
+                type: param.type.description.trimmingCharacters(in: .whitespaces),
+                hasDefaultValue: param.defaultValue != nil
+            )
+        }
+        
+        // Extract return type
+        let returnType = functionDecl.signature.returnClause?.type.description.trimmingCharacters(in: .whitespaces)
+        
+        // Check modifiers
+        let isAsync = functionDecl.signature.effectSpecifiers?.asyncSpecifier != nil
+        let isThrowing = functionDecl.signature.effectSpecifiers?.throwsSpecifier != nil
+        let isStatic = functionDecl.modifiers.contains { $0.name.text == "static" }
+        
+        // Extract access level
+        let accessLevel = extractAccessLevel(from: functionDecl.modifiers)
+        
+        return FunctionSignature(
+            name: name,
+            parameters: parameters,
+            returnType: returnType,
+            isAsync: isAsync,
+            isThrowing: isThrowing,
+            isStatic: isStatic,
+            accessLevel: accessLevel
+        )
+    }
+    
+    /// Extract access level from modifiers
+    private func extractAccessLevel(from modifiers: DeclModifierListSyntax) -> String {
+        for modifier in modifiers {
+            switch modifier.name.text {
+            case "public", "internal", "private", "fileprivate":
+                return modifier.name.text
+            default:
+                continue
+            }
+        }
+        return "internal" // Default access level
+    }
+    
+    /// Generate default return value for a given type
+    func generateDefaultReturnValue(for type: String) -> String {
+        let cleanType = type.trimmingCharacters(in: .whitespaces)
+        
+        switch cleanType {
+        case "Void", "()":
+            return ""
+        case "String":
+            return "return \"\""
+        case "Int":
+            return "return 0"
+        case "Double", "Float":
+            return "return 0.0"
+        case "Bool":
+            return "return false"
+        case let t where t.hasPrefix("[") && t.hasSuffix("]"):
+            return "return []"
+        case let t where t.hasPrefix("Set<") && t.hasSuffix(">"):
+            return "return Set()"
+        case let t where t.hasPrefix("Dictionary<") && t.hasSuffix(">"):
+            return "return [:]"
+        case let t where t.hasSuffix("?"):
+            return "return nil"
+        default:
+            if cleanType.contains("->") {
+                // Function type - return a closure that does nothing
+                return "return { _ in }"
+            } else {
+                // For custom types, try to initialize with empty initializer
+                return "return \(cleanType)()"
+            }
+        }
+    }
+}

--- a/Sources/SwiftMockGenerator/MockGenerator.swift
+++ b/Sources/SwiftMockGenerator/MockGenerator.swift
@@ -1,0 +1,92 @@
+import Foundation
+import SwiftSyntax
+import SwiftParser
+
+/// Main class responsible for parsing Swift files and generating mocks
+class MockGenerator {
+    private let outputDirectory: String
+    private let verbose: Bool
+    private let fileManager = FileManager.default
+    
+    init(outputDirectory: String, verbose: Bool = false) {
+        self.outputDirectory = outputDirectory
+        self.verbose = verbose
+    }
+    
+    /// Process a single Swift file and generate mocks for annotated declarations
+    func processFile(at path: String) throws {
+        guard fileManager.fileExists(atPath: path) else {
+            throw MockGeneratorError.fileNotFound(path)
+        }
+        
+        let sourceCode = try String(contentsOfFile: path)
+        let sourceFile = Parser.parse(source: sourceCode)
+        
+        let visitor = MockAnnotationVisitor()
+        visitor.walk(sourceFile)
+        
+        for annotation in visitor.annotations {
+            if verbose {
+                print("Found \(annotation.mockType) annotation for \(annotation.declaration.kind)")
+            }
+            
+            try generateMock(for: annotation, sourceFile: sourceFile, originalPath: path)
+        }
+    }
+    
+    /// Generate mock code based on the annotation and declaration
+    private func generateMock(for annotation: MockAnnotation, sourceFile: SourceFileSyntax, originalPath: String) throws {
+        let generator: MockCodeGenerator
+        
+        switch annotation.mockType {
+        case .stub:
+            generator = StubGenerator()
+        case .spy:
+            generator = SpyGenerator()
+        case .dummy:
+            generator = DummyGenerator()
+        }
+        
+        let mockCode = try generator.generateMock(
+            for: annotation.declaration,
+            in: sourceFile,
+            originalPath: originalPath
+        )
+        
+        try saveMockCode(mockCode, for: annotation, originalPath: originalPath)
+    }
+    
+    /// Save generated mock code to appropriate file
+    private func saveMockCode(_ code: String, for annotation: MockAnnotation, originalPath: String) throws {
+        // Create output directory if it doesn't exist
+        try fileManager.createDirectory(atPath: outputDirectory, withIntermediateDirectories: true, attributes: nil)
+        
+        let originalFileName = URL(fileURLWithPath: originalPath).deletingPathExtension().lastPathComponent
+        let mockFileName = "\(originalFileName)_\(annotation.mockType.rawValue)_\(annotation.declarationName).swift"
+        let mockFilePath = "\(outputDirectory)/\(mockFileName)"
+        
+        try code.write(toFile: mockFilePath, atomically: true, encoding: .utf8)
+        
+        if verbose {
+            print("Generated mock: \(mockFilePath)")
+        }
+    }
+}
+
+/// Errors that can occur during mock generation
+enum MockGeneratorError: Error, LocalizedError {
+    case fileNotFound(String)
+    case unsupportedDeclaration(String)
+    case invalidAnnotation(String)
+    
+    var errorDescription: String? {
+        switch self {
+        case .fileNotFound(let path):
+            return "File not found: \(path)"
+        case .unsupportedDeclaration(let type):
+            return "Unsupported declaration type: \(type)"
+        case .invalidAnnotation(let annotation):
+            return "Invalid annotation: \(annotation)"
+        }
+    }
+}

--- a/Sources/SwiftMockGenerator/MockTypes.swift
+++ b/Sources/SwiftMockGenerator/MockTypes.swift
@@ -1,0 +1,73 @@
+import SwiftSyntax
+
+/// Types of mocks that can be generated
+enum MockType: String, CaseIterable {
+    case stub = "Stub"
+    case spy = "Spy"
+    case dummy = "Dummy"
+    
+    var commentPattern: String {
+        return "@\(rawValue)"
+    }
+}
+
+/// Represents a mock annotation found in the source code
+struct MockAnnotation {
+    let mockType: MockType
+    let declaration: any DeclSyntaxProtocol
+    let declarationName: String
+    let lineNumber: Int
+    
+    init(mockType: MockType, declaration: any DeclSyntaxProtocol, declarationName: String, lineNumber: Int) {
+        self.mockType = mockType
+        self.declaration = declaration
+        self.declarationName = declarationName
+        self.lineNumber = lineNumber
+    }
+}
+
+/// Supported Swift declaration types for mock generation
+enum SupportedDeclarationType {
+    case `class`(ClassDeclSyntax)
+    case `protocol`(ProtocolDeclSyntax)
+    case `enum`(EnumDeclSyntax)
+    case function(FunctionDeclSyntax)
+    
+    var name: String {
+        switch self {
+        case .class(let decl):
+            return decl.name.text
+        case .protocol(let decl):
+            return decl.name.text
+        case .enum(let decl):
+            return decl.name.text
+        case .function(let decl):
+            return decl.name.text
+        }
+    }
+}
+
+/// Function signature information for mock generation
+struct FunctionSignature {
+    let name: String
+    let parameters: [Parameter]
+    let returnType: String?
+    let isAsync: Bool
+    let isThrowing: Bool
+    let isStatic: Bool
+    let accessLevel: String
+    
+    struct Parameter {
+        let firstName: String?  // external parameter name
+        let secondName: String  // internal parameter name
+        let type: String
+        let hasDefaultValue: Bool
+        
+        var fullName: String {
+            if let firstName = firstName {
+                return "\(firstName) \(secondName)"
+            }
+            return secondName
+        }
+    }
+}

--- a/Sources/SwiftMockGenerator/SpyGenerator.swift
+++ b/Sources/SwiftMockGenerator/SpyGenerator.swift
@@ -1,0 +1,298 @@
+import SwiftSyntax
+import Foundation
+
+/// Generates spy implementations that track method calls and parameters
+class SpyGenerator: BaseMockGenerator {
+    
+    override func generateMock(for declaration: any DeclSyntaxProtocol, in sourceFile: SourceFileSyntax, originalPath: String) throws -> String {
+        let imports = extractImports(from: sourceFile)
+        let declarationName = extractDeclarationName(from: declaration)
+        
+        var mockCode = generateHeader(originalPath: originalPath, declarationName: declarationName)
+        mockCode += generateImports(imports)
+        mockCode += "\n"
+        
+        if let classDecl = declaration.as(ClassDeclSyntax.self) {
+            mockCode += generateClassSpy(from: classDecl)
+        } else if let protocolDecl = declaration.as(ProtocolDeclSyntax.self) {
+            mockCode += generateProtocolSpy(from: protocolDecl)
+        } else if let functionDecl = declaration.as(FunctionDeclSyntax.self) {
+            mockCode += generateFunctionSpy(from: functionDecl)
+        } else {
+            throw MockGeneratorError.unsupportedDeclaration(String(describing: type(of: declaration)))
+        }
+        
+        return mockCode
+    }
+    
+    private func generateHeader(originalPath: String, declarationName: String) -> String {
+        let fileName = URL(fileURLWithPath: originalPath).lastPathComponent
+        return """
+        //
+        // \(declarationName)Spy.swift
+        // Generated spy mock from \(fileName)
+        // Created by SwiftMockGenerator
+        //
+        
+        """
+    }
+    
+    private func generateImports(_ imports: [String]) -> String {
+        var result = ""
+        for importStatement in imports {
+            result += "\(importStatement)\n"
+        }
+        if !imports.contains("Foundation") && !imports.contains(where: { $0.contains("Foundation") }) {
+            result += "import Foundation\n"
+        }
+        return result
+    }
+    
+    private func generateClassSpy(from classDecl: ClassDeclSyntax) -> String {
+        let className = classDecl.name.text
+        let spyClassName = "\(className)Spy"
+        let functions = extractFunctions(from: classDecl)
+        
+        var classCode = "class \(spyClassName): \(className) {\n"
+        
+        // Generate call tracking properties
+        classCode += generateCallTrackingProperties(for: functions)
+        classCode += "\n"
+        
+        // Generate initializer
+        classCode += "    override init() {\n"
+        classCode += "        super.init()\n"
+        classCode += "    }\n\n"
+        
+        // Generate spy methods
+        for function in functions {
+            classCode += generateSpyMethod(from: function)
+            classCode += "\n"
+        }
+        
+        // Generate verification methods
+        classCode += generateVerificationMethods(for: functions)
+        
+        classCode += "}\n"
+        return classCode
+    }
+    
+    private func generateProtocolSpy(from protocolDecl: ProtocolDeclSyntax) -> String {
+        let protocolName = protocolDecl.name.text
+        let spyClassName = "\(protocolName)Spy"
+        let functions = extractFunctions(from: protocolDecl)
+        
+        var classCode = "class \(spyClassName): \(protocolName) {\n"
+        
+        // Generate call tracking properties
+        classCode += generateCallTrackingProperties(for: functions)
+        classCode += "\n"
+        
+        // Generate initializer
+        classCode += "    init() {}\n\n"
+        
+        // Generate spy methods
+        for function in functions {
+            classCode += generateSpyMethod(from: function)
+            classCode += "\n"
+        }
+        
+        // Generate verification methods
+        classCode += generateVerificationMethods(for: functions)
+        
+        classCode += "}\n"
+        return classCode
+    }
+    
+    private func generateFunctionSpy(from functionDecl: FunctionDeclSyntax) -> String {
+        let signature = createFunctionSignature(from: functionDecl)!
+        let spyClassName = "\(signature.name)Spy"
+        
+        var classCode = "class \(spyClassName) {\n"
+        
+        // Generate call tracking properties
+        classCode += generateCallTrackingProperties(for: [signature])
+        classCode += "\n"
+        
+        // Generate initializer
+        classCode += "    init() {}\n\n"
+        
+        // Generate the spy function
+        classCode += generateSpyFunction(from: signature)
+        classCode += "\n"
+        
+        // Generate verification methods
+        classCode += generateVerificationMethods(for: [signature])
+        
+        classCode += "}\n"
+        return classCode
+    }
+    
+    private func generateCallTrackingProperties(for functions: [FunctionSignature]) -> String {
+        var properties = ""
+        
+        for function in functions {
+            let functionName = function.name
+            properties += "    private(set) var \(functionName)CallCount = 0\n"
+            properties += "    private(set) var \(functionName)Called = false\n"
+            
+            if !function.parameters.isEmpty {
+                properties += "    private(set) var \(functionName)ReceivedParameters: [(\(generateParameterTuple(from: function)))] = []\n"
+            }
+        }
+        
+        return properties
+    }
+    
+    private func generateSpyMethod(from signature: FunctionSignature) -> String {
+        var methodCode = "    \(signature.accessLevel) func \(signature.name)"
+        methodCode += generateParameterList(from: signature)
+        
+        if let returnType = signature.returnType {
+            methodCode += " -> \(returnType)"
+        }
+        
+        if signature.isAsync {
+            methodCode += " async"
+        }
+        
+        if signature.isThrowing {
+            methodCode += " throws"
+        }
+        
+        methodCode += " {\n"
+        methodCode += "        \(signature.name)CallCount += 1\n"
+        methodCode += "        \(signature.name)Called = true\n"
+        
+        if !signature.parameters.isEmpty {
+            let parameterNames = signature.parameters.map { $0.secondName }.joined(separator: ", ")
+            methodCode += "        \(signature.name)ReceivedParameters.append((\(parameterNames)))\n"
+        }
+        
+        if let returnType = signature.returnType, returnType != "Void" {
+            let defaultReturn = generateDefaultReturnValue(for: returnType)
+            methodCode += "        \(defaultReturn)\n"
+        }
+        
+        methodCode += "    }"
+        
+        return methodCode
+    }
+    
+    private func generateSpyFunction(from signature: FunctionSignature) -> String {
+        var functionCode = "    func \(signature.name)"
+        functionCode += generateParameterList(from: signature)
+        
+        if let returnType = signature.returnType {
+            functionCode += " -> \(returnType)"
+        }
+        
+        if signature.isAsync {
+            functionCode += " async"
+        }
+        
+        if signature.isThrowing {
+            functionCode += " throws"
+        }
+        
+        functionCode += " {\n"
+        functionCode += "        \(signature.name)CallCount += 1\n"
+        functionCode += "        \(signature.name)Called = true\n"
+        
+        if !signature.parameters.isEmpty {
+            let parameterNames = signature.parameters.map { $0.secondName }.joined(separator: ", ")
+            functionCode += "        \(signature.name)ReceivedParameters.append((\(parameterNames)))\n"
+        }
+        
+        if let returnType = signature.returnType, returnType != "Void" {
+            let defaultReturn = generateDefaultReturnValue(for: returnType)
+            functionCode += "        \(defaultReturn)\n"
+        }
+        
+        functionCode += "    }"
+        
+        return functionCode
+    }
+    
+    private func generateVerificationMethods(for functions: [FunctionSignature]) -> String {
+        var verificationMethods = "\n    // MARK: - Verification Methods\n"
+        
+        for function in functions {
+            let functionName = function.name
+            
+            // Method to verify if function was called
+            verificationMethods += """
+                
+                func verify\(functionName.capitalized)Called() -> Bool {
+                    return \(functionName)Called
+                }
+                
+                func verify\(functionName.capitalized)CallCount(_ expectedCount: Int) -> Bool {
+                    return \(functionName)CallCount == expectedCount
+                }
+                
+            """
+            
+            // Method to verify parameters if function has any
+            if !function.parameters.isEmpty {
+                verificationMethods += """
+                func verify\(functionName.capitalized)CalledWith(\(generateParameterList(from: function, includeTypes: true))) -> Bool {
+                    return \(functionName)ReceivedParameters.contains { receivedParams in
+                        \(generateParameterComparison(from: function))
+                    }
+                }
+                
+                """
+            }
+        }
+        
+        return verificationMethods
+    }
+    
+    private func generateParameterList(from signature: FunctionSignature, includeTypes: Bool = true) -> String {
+        guard !signature.parameters.isEmpty else { return "()" }
+        
+        let params = signature.parameters.map { param in
+            var paramStr = ""
+            if let firstName = param.firstName {
+                paramStr = "\(firstName) \(param.secondName)"
+            } else {
+                paramStr = "\(param.secondName)"
+            }
+            
+            if includeTypes {
+                paramStr += ": \(param.type)"
+            }
+            
+            return paramStr
+        }.joined(separator: ", ")
+        
+        return "(\(params))"
+    }
+    
+    private func generateParameterTuple(from signature: FunctionSignature) -> String {
+        let types = signature.parameters.map { $0.type }.joined(separator: ", ")
+        return types
+    }
+    
+    private func generateParameterComparison(from signature: FunctionSignature) -> String {
+        let comparisons = signature.parameters.enumerated().map { index, param in
+            return "receivedParams.\(index) == \(param.secondName)"
+        }.joined(separator: " && ")
+        
+        return comparisons
+    }
+    
+    private func extractDeclarationName(from declaration: any DeclSyntaxProtocol) -> String {
+        if let classDecl = declaration.as(ClassDeclSyntax.self) {
+            return classDecl.name.text
+        } else if let protocolDecl = declaration.as(ProtocolDeclSyntax.self) {
+            return protocolDecl.name.text
+        } else if let enumDecl = declaration.as(EnumDeclSyntax.self) {
+            return enumDecl.name.text
+        } else if let functionDecl = declaration.as(FunctionDeclSyntax.self) {
+            return functionDecl.name.text
+        }
+        return "Unknown"
+    }
+}

--- a/Sources/SwiftMockGenerator/StubGenerator.swift
+++ b/Sources/SwiftMockGenerator/StubGenerator.swift
@@ -1,0 +1,224 @@
+import SwiftSyntax
+import Foundation
+
+/// Generates stub implementations that return default values
+class StubGenerator: BaseMockGenerator {
+    
+    override func generateMock(for declaration: any DeclSyntaxProtocol, in sourceFile: SourceFileSyntax, originalPath: String) throws -> String {
+        let imports = extractImports(from: sourceFile)
+        let declarationName = extractDeclarationName(from: declaration)
+        
+        var mockCode = generateHeader(originalPath: originalPath, declarationName: declarationName)
+        mockCode += generateImports(imports)
+        mockCode += "\n"
+        
+        if let classDecl = declaration.as(ClassDeclSyntax.self) {
+            mockCode += generateClassStub(from: classDecl)
+        } else if let protocolDecl = declaration.as(ProtocolDeclSyntax.self) {
+            mockCode += generateProtocolStub(from: protocolDecl)
+        } else if let enumDecl = declaration.as(EnumDeclSyntax.self) {
+            mockCode += generateEnumStub(from: enumDecl)
+        } else if let functionDecl = declaration.as(FunctionDeclSyntax.self) {
+            mockCode += generateFunctionStub(from: functionDecl)
+        } else {
+            throw MockGeneratorError.unsupportedDeclaration(String(describing: type(of: declaration)))
+        }
+        
+        return mockCode
+    }
+    
+    private func generateHeader(originalPath: String, declarationName: String) -> String {
+        let fileName = URL(fileURLWithPath: originalPath).lastPathComponent
+        return """
+        //
+        // \(declarationName)Stub.swift
+        // Generated stub mock from \(fileName)
+        // Created by SwiftMockGenerator
+        //
+        
+        """
+    }
+    
+    private func generateImports(_ imports: [String]) -> String {
+        var result = ""
+        for importStatement in imports {
+            result += "\(importStatement)\n"
+        }
+        if !imports.contains("Foundation") && !imports.contains(where: { $0.contains("Foundation") }) {
+            result += "import Foundation\n"
+        }
+        return result
+    }
+    
+    private func generateClassStub(from classDecl: ClassDeclSyntax) -> String {
+        let className = classDecl.name.text
+        let stubClassName = "\(className)Stub"
+        let functions = extractFunctions(from: classDecl)
+        
+        var classCode = "class \(stubClassName): \(className) {\n"
+        
+        // Generate initializer if needed
+        classCode += "    override init() {\n"
+        classCode += "        super.init()\n"
+        classCode += "    }\n\n"
+        
+        // Generate stub methods
+        for function in functions {
+            classCode += generateStubMethod(from: function)
+            classCode += "\n"
+        }
+        
+        classCode += "}\n"
+        return classCode
+    }
+    
+    private func generateProtocolStub(from protocolDecl: ProtocolDeclSyntax) -> String {
+        let protocolName = protocolDecl.name.text
+        let stubClassName = "\(protocolName)Stub"
+        let functions = extractFunctions(from: protocolDecl)
+        
+        var classCode = "class \(stubClassName): \(protocolName) {\n"
+        
+        // Generate initializer
+        classCode += "    init() {}\n\n"
+        
+        // Generate stub methods
+        for function in functions {
+            classCode += generateStubMethod(from: function)
+            classCode += "\n"
+        }
+        
+        classCode += "}\n"
+        return classCode
+    }
+    
+    private func generateEnumStub(from enumDecl: EnumDeclSyntax) -> String {
+        let enumName = enumDecl.name.text
+        let stubClassName = "\(enumName)Stub"
+        
+        // For enums, we create a helper class that can provide stub values
+        var classCode = "class \(stubClassName) {\n"
+        classCode += "    static let defaultValue: \(enumName) = .\(extractFirstCase(from: enumDecl))\n"
+        classCode += "    \n"
+        classCode += "    static func randomValue() -> \(enumName) {\n"
+        classCode += "        let allCases: [\(enumName)] = [\(generateAllCases(from: enumDecl))]\n"
+        classCode += "        return allCases.randomElement() ?? defaultValue\n"
+        classCode += "    }\n"
+        classCode += "}\n"
+        
+        return classCode
+    }
+    
+    private func generateFunctionStub(from functionDecl: FunctionDeclSyntax) -> String {
+        let signature = createFunctionSignature(from: functionDecl)!
+        let functionName = "\(signature.name)Stub"
+        
+        var functionCode = "func \(functionName)"
+        functionCode += generateParameterList(from: signature)
+        
+        if let returnType = signature.returnType {
+            functionCode += " -> \(returnType)"
+        }
+        
+        if signature.isAsync {
+            functionCode += " async"
+        }
+        
+        if signature.isThrowing {
+            functionCode += " throws"
+        }
+        
+        functionCode += " {\n"
+        
+        if let returnType = signature.returnType, returnType != "Void" {
+            let defaultReturn = generateDefaultReturnValue(for: returnType)
+            functionCode += "    \(defaultReturn)\n"
+        }
+        
+        functionCode += "}\n"
+        
+        return functionCode
+    }
+    
+    private func generateStubMethod(from signature: FunctionSignature) -> String {
+        var methodCode = "    \(signature.accessLevel) func \(signature.name)"
+        methodCode += generateParameterList(from: signature)
+        
+        if let returnType = signature.returnType {
+            methodCode += " -> \(returnType)"
+        }
+        
+        if signature.isAsync {
+            methodCode += " async"
+        }
+        
+        if signature.isThrowing {
+            methodCode += " throws"
+        }
+        
+        methodCode += " {\n"
+        
+        if let returnType = signature.returnType, returnType != "Void" {
+            let defaultReturn = generateDefaultReturnValue(for: returnType)
+            methodCode += "        \(defaultReturn)\n"
+        }
+        
+        methodCode += "    }"
+        
+        return methodCode
+    }
+    
+    private func generateParameterList(from signature: FunctionSignature) -> String {
+        guard !signature.parameters.isEmpty else { return "()" }
+        
+        let params = signature.parameters.map { param in
+            var paramStr = ""
+            if let firstName = param.firstName {
+                paramStr = "\(firstName) \(param.secondName): \(param.type)"
+            } else {
+                paramStr = "\(param.secondName): \(param.type)"
+            }
+            return paramStr
+        }.joined(separator: ", ")
+        
+        return "(\(params))"
+    }
+    
+    private func extractDeclarationName(from declaration: any DeclSyntaxProtocol) -> String {
+        if let classDecl = declaration.as(ClassDeclSyntax.self) {
+            return classDecl.name.text
+        } else if let protocolDecl = declaration.as(ProtocolDeclSyntax.self) {
+            return protocolDecl.name.text
+        } else if let enumDecl = declaration.as(EnumDeclSyntax.self) {
+            return enumDecl.name.text
+        } else if let functionDecl = declaration.as(FunctionDeclSyntax.self) {
+            return functionDecl.name.text
+        }
+        return "Unknown"
+    }
+    
+    private func extractFirstCase(from enumDecl: EnumDeclSyntax) -> String {
+        for member in enumDecl.memberBlock.members {
+            if let caseDecl = member.decl.as(EnumCaseDeclSyntax.self) {
+                if let firstCase = caseDecl.elements.first {
+                    return firstCase.name.text
+                }
+            }
+        }
+        return "defaultCase"
+    }
+    
+    private func generateAllCases(from enumDecl: EnumDeclSyntax) -> String {
+        var cases: [String] = []
+        
+        for member in enumDecl.memberBlock.members {
+            if let caseDecl = member.decl.as(EnumCaseDeclSyntax.self) {
+                for element in caseDecl.elements {
+                    cases.append(".\(element.name.text)")
+                }
+            }
+        }
+        
+        return cases.joined(separator: ", ")
+    }
+}

--- a/Sources/SwiftMockGenerator/main.swift
+++ b/Sources/SwiftMockGenerator/main.swift
@@ -1,0 +1,48 @@
+import ArgumentParser
+import Foundation
+import SwiftSyntax
+import SwiftParser
+
+@main
+struct SwiftMockGenerator: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "swift-mock-generator",
+        abstract: "A Swift tool for generating mocks from annotated source code",
+        discussion: """
+        This tool parses Swift source files and generates mock objects based on special comments:
+        - // @Stub - Creates a stub implementation
+        - // @Spy - Creates a spy that tracks method calls
+        - // @Dummy - Creates a minimal dummy implementation
+        
+        Supports classes, protocols, enums, and various function types including async and throwing functions.
+        """
+    )
+    
+    @Argument(help: "Swift source files to process")
+    var inputFiles: [String] = []
+    
+    @Option(name: .shortAndLong, help: "Output directory for generated mocks")
+    var output: String = "Generated"
+    
+    @Flag(name: .shortAndLong, help: "Enable verbose output")
+    var verbose: Bool = false
+    
+    func run() throws {
+        if inputFiles.isEmpty {
+            print("Error: No input files specified")
+            throw ExitCode.failure
+        }
+        
+        let generator = MockGenerator(outputDirectory: output, verbose: verbose)
+        
+        for inputFile in inputFiles {
+            if verbose {
+                print("Processing file: \(inputFile)")
+            }
+            
+            try generator.processFile(at: inputFile)
+        }
+        
+        print("Mock generation completed successfully!")
+    }
+}

--- a/Tests/SwiftMockGeneratorTests/SwiftMockGeneratorTests.swift
+++ b/Tests/SwiftMockGeneratorTests/SwiftMockGeneratorTests.swift
@@ -1,0 +1,139 @@
+import XCTest
+@testable import SwiftMockGenerator
+import SwiftSyntax
+import SwiftParser
+
+final class SwiftMockGeneratorTests: XCTestCase {
+    
+    func testStubGeneration() throws {
+        let sourceCode = """
+        import Foundation
+        
+        // @Stub
+        protocol TestProtocol {
+            func testMethod() -> String
+        }
+        """
+        
+        let sourceFile = Parser.parse(source: sourceCode)
+        let visitor = MockAnnotationVisitor()
+        visitor.walk(sourceFile)
+        
+        XCTAssertEqual(visitor.annotations.count, 1)
+        XCTAssertEqual(visitor.annotations.first?.mockType, .stub)
+        XCTAssertEqual(visitor.annotations.first?.declarationName, "TestProtocol")
+    }
+    
+    func testSpyGeneration() throws {
+        let sourceCode = """
+        import Foundation
+        
+        // @Spy
+        class TestClass {
+            func testMethod(param: String) -> Bool {
+                return true
+            }
+        }
+        """
+        
+        let sourceFile = Parser.parse(source: sourceCode)
+        let visitor = MockAnnotationVisitor()
+        visitor.walk(sourceFile)
+        
+        XCTAssertEqual(visitor.annotations.count, 1)
+        XCTAssertEqual(visitor.annotations.first?.mockType, .spy)
+        XCTAssertEqual(visitor.annotations.first?.declarationName, "TestClass")
+    }
+    
+    func testDummyGeneration() throws {
+        let sourceCode = """
+        import Foundation
+        
+        // @Dummy
+        enum TestEnum {
+            case case1
+            case case2
+        }
+        """
+        
+        let sourceFile = Parser.parse(source: sourceCode)
+        let visitor = MockAnnotationVisitor()
+        visitor.walk(sourceFile)
+        
+        XCTAssertEqual(visitor.annotations.count, 1)
+        XCTAssertEqual(visitor.annotations.first?.mockType, .dummy)
+        XCTAssertEqual(visitor.annotations.first?.declarationName, "TestEnum")
+    }
+    
+    func testAsyncFunctionParsing() throws {
+        let sourceCode = """
+        import Foundation
+        
+        // @Stub
+        func asyncFunction() async throws -> Data {
+            return Data()
+        }
+        """
+        
+        let sourceFile = Parser.parse(source: sourceCode)
+        let visitor = MockAnnotationVisitor()
+        visitor.walk(sourceFile)
+        
+        XCTAssertEqual(visitor.annotations.count, 1)
+        
+        if let functionDecl = visitor.annotations.first?.declaration as? FunctionDeclSyntax {
+            let generator = StubGenerator()
+            let signature = generator.createFunctionSignature(from: functionDecl)
+            
+            XCTAssertNotNil(signature)
+            XCTAssertTrue(signature!.isAsync)
+            XCTAssertTrue(signature!.isThrowing)
+            XCTAssertEqual(signature!.returnType, "Data")
+        }
+    }
+    
+    func testFunctionSignatureExtraction() throws {
+        let sourceCode = """
+        class TestClass {
+            func complexMethod(first param1: String, _ param2: Int, third param3: Bool = true) -> [String] {
+                return []
+            }
+        }
+        """
+        
+        let sourceFile = Parser.parse(source: sourceCode)
+        let classDecl = sourceFile.statements.first?.item.as(ClassDeclSyntax.self)
+        XCTAssertNotNil(classDecl)
+        
+        let generator = StubGenerator()
+        let functions = generator.extractFunctions(from: classDecl!)
+        
+        XCTAssertEqual(functions.count, 1)
+        
+        let function = functions.first!
+        XCTAssertEqual(function.name, "complexMethod")
+        XCTAssertEqual(function.parameters.count, 3)
+        XCTAssertEqual(function.parameters[0].firstName, "first")
+        XCTAssertEqual(function.parameters[0].secondName, "param1")
+        XCTAssertEqual(function.parameters[1].firstName, "_")
+        XCTAssertEqual(function.parameters[1].secondName, "param2")
+        XCTAssertEqual(function.parameters[2].hasDefaultValue, true)
+        XCTAssertEqual(function.returnType, "[String]")
+    }
+    
+    func testNoAnnotationsParsing() throws {
+        let sourceCode = """
+        import Foundation
+        
+        protocol TestProtocol {
+            func testMethod() -> String
+        }
+        """
+        
+        let sourceFile = Parser.parse(source: sourceCode)
+        let visitor = MockAnnotationVisitor()
+        visitor.walk(sourceFile)
+        
+        XCTAssertEqual(visitor.annotations.count, 0)
+    }
+}

--- a/USAGE.md
+++ b/USAGE.md
@@ -1,0 +1,244 @@
+# SwiftMockGenerator Usage Guide
+
+## Quick Start
+
+1. **Build the tool:**
+   ```bash
+   ./build.sh
+   ```
+
+2. **Add mock annotations to your Swift code:**
+   ```swift
+   // @Stub
+   protocol MyProtocol {
+       func doSomething() -> String
+   }
+   ```
+
+3. **Generate mocks:**
+   ```bash
+   ./.build/release/swift-mock-generator YourFile.swift
+   ```
+
+4. **Use generated mocks in tests:**
+   ```swift
+   let stub = MyProtocolStub()
+   XCTAssertEqual(stub.doSomething(), "")
+   ```
+
+## Annotation Types
+
+### @Stub
+- **Purpose**: Create working implementations with sensible default return values
+- **Best for**: Dependency injection where you need a functioning object
+- **Returns**: Default values (empty strings, zero numbers, nil optionals, empty collections)
+
+### @Spy
+- **Purpose**: Track method calls and verify interactions
+- **Best for**: Testing that methods are called with correct parameters
+- **Features**: 
+  - Call count tracking
+  - Parameter recording
+  - Verification methods
+  - Still provides default return values
+
+### @Dummy
+- **Purpose**: Minimal implementations for objects that shouldn't be used
+- **Best for**: Required dependencies that won't be called in test scenarios
+- **Behavior**: Often calls `fatalError()` for custom types to catch unexpected usage
+
+## Supported Declaration Types
+
+### Classes
+```swift
+// @Spy
+class UserService {
+    func login(username: String) async throws -> Bool {
+        return true
+    }
+}
+```
+**Generates**: `UserServiceSpy` that inherits from `UserService`
+
+### Protocols
+```swift
+// @Stub
+protocol DataRepository {
+    func save(_ item: Item) throws
+    func load(id: String) -> Item?
+}
+```
+**Generates**: `DataRepositoryStub` that implements `DataRepository`
+
+### Enums
+```swift
+// @Dummy
+enum APIError: Error {
+    case networkError
+    case parseError
+}
+```
+**Generates**: `APIErrorDummy` helper class with static values
+
+### Functions
+```swift
+// @Stub
+func validateInput(_ input: String) -> ValidationResult {
+    return .valid
+}
+```
+**Generates**: `validateInputStub()` function with default behavior
+
+## Advanced Features
+
+### Async/Await Support
+```swift
+// @Stub
+func fetchData() async throws -> Data {
+    return Data()
+}
+```
+Generated stub maintains `async throws` signature.
+
+### Callback Support
+```swift
+// @Spy
+func processRequest(
+    completion: @escaping (Result<String, Error>) -> Void
+) {
+    completion(.success("result"))
+}
+```
+Generated spy tracks callback parameters and execution.
+
+### Generic Functions
+```swift
+// @Stub
+func transform<T>(_ items: [T], using: (T) -> T) -> [T] {
+    return items.map(using)
+}
+```
+Generated stub maintains generic constraints.
+
+### Complex Parameter Types
+```swift
+// @Spy
+func complexMethod(
+    _ first: String,
+    second value: Int = 10,
+    third: @escaping (String) -> Bool
+) -> [String: Any] {
+    return [:]
+}
+```
+Generated spy properly handles:
+- Unnamed parameters (`_`)
+- Default values
+- External parameter names
+- Closure parameters
+
+## Testing Integration
+
+### Using Stubs
+```swift
+func testWithStub() {
+    let dataService = DataServiceStub()
+    let manager = DataManager(service: dataService)
+    
+    // Test uses stub's default behavior
+    let result = manager.processData()
+    XCTAssertNotNil(result)
+}
+```
+
+### Using Spies
+```swift
+func testWithSpy() async throws {
+    let networkSpy = NetworkServiceSpy()
+    let manager = NetworkManager(service: networkSpy)
+    
+    try await manager.syncData()
+    
+    // Verify interactions
+    XCTAssertTrue(networkSpy.verifySyncDataCalled())
+    XCTAssertEqual(networkSpy.syncDataCallCount, 1)
+}
+```
+
+### Using Dummies
+```swift
+func testWithDummy() {
+    let logger = LoggerDummy() // Won't be called in this test
+    let service = CriticalService(logger: logger)
+    
+    // Test critical path without logging
+    let result = service.performCriticalOperation()
+    XCTAssertTrue(result)
+}
+```
+
+## Best Practices
+
+1. **Use appropriate mock types:**
+   - **Stub**: When you need working implementations
+   - **Spy**: When you need to verify method calls
+   - **Dummy**: When you need objects that won't be used
+
+2. **Place annotations carefully:**
+   - Put annotation comment directly above the declaration
+   - Use exact format: `// @Stub`, `// @Spy`, or `// @Dummy`
+
+3. **Organize generated files:**
+   - Use `--output` to specify a dedicated directory
+   - Consider organizing by test suite or feature
+
+4. **Combine with dependency injection:**
+   ```swift
+   class MyService {
+       private let repository: DataRepository
+       
+       init(repository: DataRepository = DataRepositoryStub()) {
+           self.repository = repository
+       }
+   }
+   ```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **No mocks generated:**
+   - Check annotation format (exact spacing: `// @Stub`)
+   - Ensure annotation is directly above declaration
+   - Verify file has proper Swift syntax
+
+2. **Compilation errors in generated mocks:**
+   - Check that all referenced types are imported
+   - Verify original code compiles correctly
+   - Check for complex generic constraints
+
+3. **Spy verification not working:**
+   - Ensure you're calling the spy's methods, not the original
+   - Check parameter types match exactly
+   - Verify method names are correct
+
+### Debug Output
+
+Use `--verbose` flag to see detailed generation process:
+```bash
+swift-mock-generator MyFile.swift --verbose
+```
+
+This will show:
+- Files being processed
+- Annotations found
+- Generated mock file paths
+
+## Contributing
+
+To add support for new Swift features:
+
+1. Update `MockAnnotationVisitor` to handle new syntax nodes
+2. Extend generators to support new patterns
+3. Add tests in `SwiftMockGeneratorTests`
+4. Update examples and documentation

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# SwiftMockGenerator Build Script
+
+set -e
+
+echo "🔨 Building SwiftMockGenerator..."
+
+# Clean previous builds
+echo "🧹 Cleaning previous builds..."
+rm -rf .build
+
+# Build the project
+echo "⚙️  Building executable..."
+swift build -c release
+
+# Check if build was successful
+if [ $? -eq 0 ]; then
+    echo "✅ Build successful!"
+    echo ""
+    echo "📦 Executable created at: .build/release/swift-mock-generator"
+    echo ""
+    echo "💡 To install globally, run:"
+    echo "   sudo cp .build/release/swift-mock-generator /usr/local/bin/"
+    echo ""
+    echo "🚀 To test with example code:"
+    echo "   ./.build/release/swift-mock-generator Examples/ExampleCode.swift --verbose"
+else
+    echo "❌ Build failed!"
+    exit 1
+fi

--- a/example_usage.sh
+++ b/example_usage.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# SwiftMockGenerator Example Usage Script
+
+set -e
+
+echo "🧪 SwiftMockGenerator Example Usage"
+echo ""
+
+# Ensure the tool is built
+if [ ! -f ".build/release/swift-mock-generator" ]; then
+    echo "⚠️  Executable not found. Building first..."
+    ./build.sh
+fi
+
+# Create Examples directory if it doesn't exist
+mkdir -p Examples
+
+# Run the mock generator on the example file
+echo "🎯 Generating mocks from Examples/ExampleCode.swift..."
+./.build/release/swift-mock-generator Examples/ExampleCode.swift --output Generated --verbose
+
+echo ""
+echo "✅ Mock generation completed!"
+echo ""
+
+# Show generated files
+if [ -d "Generated" ]; then
+    echo "📁 Generated mock files:"
+    ls -la Generated/
+    echo ""
+    
+    echo "🔍 Example of generated stub:"
+    if ls Generated/*Stub*.swift 1> /dev/null 2>&1; then
+        echo "--- Content of first stub file ---"
+        head -20 Generated/*Stub*.swift | head -20
+        echo ""
+    fi
+    
+    echo "🔍 Example of generated spy:"
+    if ls Generated/*Spy*.swift 1> /dev/null 2>&1; then
+        echo "--- Content of first spy file ---"
+        head -20 Generated/*Spy*.swift | head -20
+        echo ""
+    fi
+else
+    echo "⚠️  No Generated directory found. Check for errors above."
+fi
+
+echo "🎉 Done! Check the Generated/ directory for your mock files."


### PR DESCRIPTION
Implement `SwiftMockGenerator` CLI tool to automatically generate stubs, spies, and dummies from annotated Swift code for testing.

---
<a href="https://cursor.com/background-agent?bcId=bc-7ed40b3e-83af-4879-af60-05664d1ff7cf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7ed40b3e-83af-4879-af60-05664d1ff7cf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

