### PR TITLE
Enables code coverage reporting

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -60,13 +60,22 @@ jobs:
       - name: Run tests
         run: swift test --configuration release --parallel --enable-code-coverage
         
+      - name: Verify coverage files
+        run: |
+          echo "Checking for coverage files..."
+          find .build -name "*.json" -type f | grep -i codecov || echo "No codecov files found"
+          echo "All codecov directories:"
+          find .build -name "codecov" -type d
+          echo "Coverage files found:"
+          find .build -name "*.json" -path "*/codecov/*" -exec ls -la {} \;
+        
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: .build/debug/codecov/*.json
           fail_ci_if_error: false
           verbose: true
+          directory: .build/
           
       - name: Build executable
         run: swift build --configuration release --product swift-mock-generator

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -87,9 +87,12 @@ jobs:
             exit 1
           fi
           
-          TEST_EXECUTABLE=$(find "$TEST_XCTEST_DIR/Contents/MacOS" -type f | head -1)
+          # Look for the main executable (exclude dSYM directories and other files)
+          TEST_EXECUTABLE=$(find "$TEST_XCTEST_DIR/Contents/MacOS" -type f -maxdepth 1 ! -name "*.dSYM" ! -name "*.yml" ! -name "*.plist" | head -1)
           if [ -z "$TEST_EXECUTABLE" ] || [ ! -f "$TEST_EXECUTABLE" ]; then
             echo "No test executable found in $TEST_XCTEST_DIR/Contents/MacOS"
+            echo "Available files:"
+            ls -la "$TEST_XCTEST_DIR/Contents/MacOS/"
             exit 1
           fi
           

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -58,8 +58,16 @@ jobs:
         run: swift build --configuration release
         
       - name: Run tests
-        run: swift test --configuration release --parallel
+        run: swift test --configuration release --parallel --enable-code-coverage
         
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: .build/debug/codecov/*.json
+          fail_ci_if_error: false
+          verbose: true
+          
       - name: Build executable
         run: swift build --configuration release --product swift-mock-generator
         

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -68,14 +68,48 @@ jobs:
           find .build -name "codecov" -type d
           echo "Coverage files found:"
           find .build -name "*.json" -path "*/codecov/*" -exec ls -la {} \;
+          
+      - name: Convert coverage to LCOV format
+        run: |
+          # Find the profdata file
+          PROFDATA_FILE=$(find .build -name "*.profdata" | head -1)
+          if [ -z "$PROFDATA_FILE" ]; then
+            echo "No profdata file found"
+            exit 1
+          fi
+          
+          echo "Found profdata file: $PROFDATA_FILE"
+          
+          # Find the test executable
+          TEST_XCTEST_DIR=$(find .build -name "*Tests.xctest" -type d | head -1)
+          if [ -z "$TEST_XCTEST_DIR" ]; then
+            echo "No test xctest directory found"
+            exit 1
+          fi
+          
+          TEST_EXECUTABLE=$(find "$TEST_XCTEST_DIR/Contents/MacOS" -type f | head -1)
+          if [ -z "$TEST_EXECUTABLE" ] || [ ! -f "$TEST_EXECUTABLE" ]; then
+            echo "No test executable found in $TEST_XCTEST_DIR/Contents/MacOS"
+            exit 1
+          fi
+          
+          echo "Found test executable: $TEST_EXECUTABLE"
+          
+          # Convert to LCOV format
+          xcrun llvm-cov export -format="lcov" "$TEST_EXECUTABLE" -instr-profile "$PROFDATA_FILE" > coverage.lcov
+          
+          echo "Generated coverage.lcov file:"
+          ls -la coverage.lcov
+          echo "First few lines of coverage file:"
+          head -10 coverage.lcov
         
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          file: coverage.lcov
           fail_ci_if_error: false
           verbose: true
-          directory: .build/
           
       - name: Build executable
         run: swift build --configuration release --product swift-mock-generator

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,37 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+  status:
+    project:
+      default:
+        target: 80%
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        target: 80%
+        threshold: 1%
+
+comment:
+  layout: "reach,diff,files,footer"
+  behavior: default
+  require_changes: false
+  require_base: no
+  require_head: yes
+
+github_checks:
+  annotations: true
+
+ignore:
+  - "Examples/"
+  - "Tests/"
+  - ".build/"
+  - "Package.resolved"
+  - "README.md"
+  - "LICENSE"
+  - "Makefile"

--- a/codecov.yml
+++ b/codecov.yml
@@ -35,3 +35,4 @@ ignore:
   - "README.md"
   - "LICENSE"
   - "Makefile"
+  - "coverage.lcov"


### PR DESCRIPTION
Adds code coverage generation and upload to Codecov.

This allows us to track code coverage changes and ensure that tests are covering the codebase adequately. It also configures Codecov to fail CI if coverage decreases below a set threshold.
